### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ function Watcher() {
   this.map = {}
   // filename -> watcher lookup
   this.watchers = {}
+  // variable for fixin problem with Windows with double fire
+  this.lastFire=[null,'',0];
 }
 
 Watcher.prototype.watch = function (name, files) {
@@ -42,6 +44,9 @@ Watcher.prototype.watch = function (name, files) {
       watchers[filename] = watch(filename, {
         persistent: true
       }, function (event) {
+        // Catch event clone
+        if (self.lastFire[0]===event[0]&&self.lastFire[1]===event[1]&&(new Date())-self.lastFire[2]<20) return; 
+        self.lastFire=[event[0],event[1],new Date()];
         // filename is not guaranteed to be emitted with fs.watch,
         // so we make sure to emit `filename` ourselves.
         debug('%s: %s', event, filename)


### PR DESCRIPTION
Fix problem with duplicate fire in Windows OS. It's about creating variable, that informs about last event. If event type and filename are equals and delay between events is smaller than 20 ms, then event ignored. Tested on Windows 8.